### PR TITLE
Use parse_known_args in build_docs.py

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -21,7 +21,7 @@ def get_abs_path(path, root):
 
 
 if __name__ == '__main__':
-    args = parser.parse_args()
+    args = parser.parse_known_args()
 
     docs_dir = pathlib.Path(__file__).parent.absolute()
     work_dir = get_abs_path(path=args.work_dir, root=docs_dir)

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -21,7 +21,7 @@ def get_abs_path(path, root):
 
 
 if __name__ == '__main__':
-    args = parser.parse_known_args()
+    args = parser.parse_known_args()[0]
 
     docs_dir = pathlib.Path(__file__).parent.absolute()
     work_dir = get_abs_path(path=args.work_dir, root=docs_dir)


### PR DESCRIPTION
To be more flexible when using the shared pipelines.